### PR TITLE
Call Entity:SetOwner when creating propeller

### DIFF
--- a/lua/entities/base_glide_plane/init.lua
+++ b/lua/entities/base_glide_plane/init.lua
@@ -58,6 +58,7 @@ function ENT:CreatePropeller( offset, radius, slowModel, fastModel )
 
     self:DeleteOnRemove( prop )
 
+    prop:SetOwner( self )
     prop:SetParent( self )
     prop:SetLocalPos( offset )
     prop:Spawn()


### PR DESCRIPTION
Adds a call to `Entity:SetOwner` on the `glide_rotor` created in `ENT:CreatePropeller` for `base_glide_plane`.

Some prop protection addons check/detour this function to help decide the owner an entity should have.

In those cases, this fixes damage applied by the rotor to be correctly attributed to the plane's owner. This function is already called when creating wheels so their owner gets correctly set.